### PR TITLE
Improved the performance of normalizing quaternions and vectors

### DIFF
--- a/src/helper_3dmath.h
+++ b/src/helper_3dmath.h
@@ -75,11 +75,11 @@ class Quaternion {
         }
         
         void normalize() {
-            float m = getMagnitude();
-            w /= m;
-            x /= m;
-            y /= m;
-            z /= m;
+            const float im = 1.0f / getMagnitude();
+            w *= im;
+            x *= im;
+            y *= im;
+            z *= im;
         }
         
         Quaternion getNormalized() {
@@ -112,10 +112,10 @@ class VectorInt16 {
         }
 
         void normalize() {
-            float m = getMagnitude();
-            x /= m;
-            y /= m;
-            z /= m;
+            const float im = 1.0f / getMagnitude();
+            x *= im;
+            y *= im;
+            z *= im;
         }
         
         VectorInt16 getNormalized() {
@@ -179,10 +179,10 @@ class VectorFloat {
         }
 
         void normalize() {
-            float m = getMagnitude();
-            x /= m;
-            y /= m;
-            z /= m;
+            const float m = 1.0f / getMagnitude();
+            x *= m;
+            y *= m;
+            z *= m;
         }
         
         VectorFloat getNormalized() {


### PR DESCRIPTION
Multiplication performed by the CPU is much faster than division. To optimize the normalize functions the magnitude is inverted and then each element is multiplied by the inverted magnitude. To further improve performance the fast inverse square root can be implemented to calculate the inverse magnitude at a cost of accuracy.