### PR TITLE
Adding support for SAM architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more info, see https://www.arduino.cc/en/Guide/Libraries
 
 - Support for SAMD21 or ARM
 - Support ESP32 and ESP8266
+- Support for SAM
 
 ### Original Library
 

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=MPU6050 Arduino Library.
 paragraph=MPU-6050 6-axis accelerometer/gyroscope Arduino Library.
 category=Sensors
 url=https://github.com/electroniccats/mpu6050
-architectures=avr,samd,esp8266,esp32,stm32
+architectures=avr,samd,sam,esp8266,esp32,stm32
 includes=MPU6050.h

--- a/src/MPU6050.h
+++ b/src/MPU6050.h
@@ -44,7 +44,7 @@ THE SOFTWARE.
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
-#elif defined(ARDUINO_ARCH_SAMD)
+#elif defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM)
 #include <avr/dtostrf.h>
     #ifndef BUFFER_LENGTH
         #define BUFFER_LENGTH 32


### PR DESCRIPTION
I use this library with an arduino Due wich is actually a SAM architecture, very similar to the SAMD.

I twicked two lines to enable SAM support.

I haven't fully tested the whole lib but it seems to work like a charm.