### PR TITLE
Update readme.MD and processing libraries links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,45 @@
+# MPU6050 by Electronic Cats - Library for Arduino
 [![LibraryBuild](https://github.com/ElectronicCats/mpu6050/actions/workflows/LibraryBuild.yml/badge.svg)](https://github.com/ElectronicCats/mpu6050/actions/workflows/LibraryBuild.yml)
 
-# MPU6050 by Electronic Cats
+Arduino library for controlling MPU6050 module.
 
-MPU-6050 6-axis accelerometer/gyroscope Arduino Library
-adapted for Arduino Library Manager by Electronic Cats, Feb 2019
-
-The MPU6050 combines a 3-axis gyroscope and a 3-axis accelerometer on the same silicon die together with
+MPU6050 Combines a 3-axis gyroscope and a 3-axis accelerometer on the same silicon die together with
 an onboard Digital Motion Processor(DMP) which processes complex 6-axis MotionFusion algorithms.
-
-### Quick Installing
-
-To install, use the Arduino Library Manager and search for "mpu6050" and install the library.
-
-### Manual Installing
-To install this library:
-
- - install it using the Arduino Library manager ("Sketch" -> "Include
-   Library" -> "Manage Libraries..."), or
- - download a zipfile from github using the "Download ZIP" button and
-   install it using the IDE ("Sketch" -> "Include Library" -> "Add .ZIP
-   Library..."
- - clone this git repository into your sketchbook/libraries folder.
-
-For more info, see https://www.arduino.cc/en/Guide/Libraries
 
 ## Features of this version
 
-- Support for SAMD21 or ARM
-- Support ESP32 and ESP8266
-- Support for SAM
-- Support for RENESAS
+- ### Supported Chipsets
+  - AVR
+  - SAM
+  - SAMD21 
+  - ARM
+  - ESP32 
+  - ESP8266
+  - RENESAS
+  
 
-### Original Library
+#### Original Library
 
 Based in the work of [jrowberg/i2cdevlib](https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050)
 
-### Maintainer
+## Quick Installing
+
+To install, use the [Arduino Library Manager](https://support.arduino.cc/hc/en-us/articles/5145457742236-Add-libraries-to-Arduino-IDE) and search for "MPU6050" and install the MPU6050 by Electronic Cats library.
+
+##  Wiki and Getting Started
+For more information please visit: [**Getting Started in our Wiki**](https://github.com/ElectronicCats/mpu6050/wiki)
+
+<a href="https://github.com/ElectronicCats/mpu6050/wiki">
+  <img src="https://user-images.githubusercontent.com/107638696/241324971-43b8fe88-447d-4c2d-9296-4b3aaa50f4ce.png" height="400" />
+</a>
+
+
+## Maintainer
 
 <a href="https://github.com/sponsors/ElectronicCats">
+ <p align="center">
   <img src="https://electroniccats.com/wp-content/uploads/2020/07/Badge_GHS.png" height="104" />
+ </p>
 </a>
 
 Electronic Cats invests time and resources providing this open source design, please support Electronic Cats and open-source hardware by purchasing products from Electronic Cats!
-
-### License
-
-MIT
-
-

--- a/examples/MPU6050_DMP6/Processing/MPUTeapot/MPUTeapot.pde
+++ b/examples/MPU6050_DMP6/Processing/MPUTeapot/MPUTeapot.pde
@@ -35,7 +35,7 @@ import toxi.geom.*;
 import toxi.processing.*;
 
 // NOTE: requires ToxicLibs to be installed in order to run properly.
-// 1. Download from http://toxiclibs.org/downloads
+// 1. Download from https://github.com/postspectacular/toxiclibs/releases
 // 2. Extract into [userdir]/Processing/libraries
 //    (location may be different on Mac/Linux)
 // 3. Run and bask in awesomeness

--- a/examples/MPU6050_DMP6_ESPWiFi/Processing/MPUOSCTeapot/MPUOSCTeapot.pde
+++ b/examples/MPU6050_DMP6_ESPWiFi/Processing/MPUOSCTeapot/MPUOSCTeapot.pde
@@ -45,8 +45,7 @@ THE SOFTWARE.
  * Open Sound Control library
  *   oscP5 website at http://www.sojamo.de/oscP5
  * ToxicLibs
- *   quaternion functions http://toxiclibs.org/
- *
+ *   quaternion functions https://github.com/postspectacular/toxiclibs/
  */
 
 // Install oscP5 using the IDE library manager.
@@ -54,9 +53,9 @@ THE SOFTWARE.
 // In the search box type "osc".
 import oscP5.*;
 import netP5.*;
-// Install ToxicLibs using the IDE library manager
-// From the IDE menu bar, Sketch | Import Library | Add library.
-// In the search box type "toxic".
+// 1. Download from https://github.com/postspectacular/toxiclibs/releases
+// 2. Extract into [userdir]/Processing/libraries
+//    (location may be different on Mac/Linux)
 import toxi.geom.*;
 import toxi.processing.*;
 

--- a/examples/MPU6050_DMP6_using_DMP_V6v12/MPUplane/MPUplane.pde
+++ b/examples/MPU6050_DMP6_using_DMP_V6v12/MPUplane/MPUplane.pde
@@ -38,7 +38,7 @@ import toxi.geom.*;
 import toxi.processing.*;
 
 // NOTE: requires ToxicLibs to be installed in order to run properly.
-// 1. Download from http://toxiclibs.org/downloads
+// 1. Download from https://github.com/postspectacular/toxiclibs/releases
 // 2. Extract into [userdir]/Processing/libraries
 //    (location may be different on Mac/Linux)
 // 3. Run and bask in awesomeness


### PR DESCRIPTION
- Update readme.MD for a better understanding and also include the wiki link.
- Update the processing (toxiclibs) library download links to the current and maintained repository, tested and working fine.