### PR TITLE
Initialize using gravity vectors to exclude the influence of the orientation during initialization

### DIFF
--- a/src/MPU6050.cpp
+++ b/src/MPU6050.cpp
@@ -3424,7 +3424,11 @@ void MPU6050_Base::PID(uint8_t ReadAddress, float kP,float kI, uint8_t Loops){
 					v_rawG.x = rawG[0];
 					v_rawG.y = rawG[1];
 					v_rawG.z = rawG[2];
-					v_normG = v_rawG.getNormalized();
+					if (v_rawG.getMagnitude() < gravity) {
+						// do nothing
+					}else {
+						v_normG = v_rawG.getNormalized();
+					}
 					Reading[0] -= gravity * v_normG.x;	//remove Gravity
 					Reading[1] -= gravity * v_normG.y;
 					Reading[2] -= gravity * v_normG.z;

--- a/src/MPU6050.cpp
+++ b/src/MPU6050.cpp
@@ -3401,6 +3401,7 @@ void MPU6050_Base::PID(uint8_t ReadAddress, float kP,float kI, uint8_t Loops){
 	uint32_t eSum;
 	uint16_t gravity = 8192; // prevent uninitialized compiler warning
 	if (ReadAddress == 0x3B) gravity = 16384 >> getFullScaleAccelRange();
+	uint16_t epsilon = gravity * 0.001;
 	Serial.write('>');
 	for (int i = 0; i < 3; i++) {
 		I2Cdev::readWords(devAddr, SaveAddress + (i * shift), 1, (uint16_t *)&Data, I2Cdev::readTimeout, wireObj); // reads 1 or more 16 bit integers (Word)
@@ -3424,7 +3425,7 @@ void MPU6050_Base::PID(uint8_t ReadAddress, float kP,float kI, uint8_t Loops){
 					v_rawG.x = rawG[0];
 					v_rawG.y = rawG[1];
 					v_rawG.z = rawG[2];
-					if (v_rawG.getMagnitude() < gravity) {
+					if (v_rawG.getMagnitude() < gravity + epsilon && v_rawG.getMagnitude() > gravity - epsilon) {
 						// do nothing
 					}else {
 						v_normG = v_rawG.getNormalized();


### PR DESCRIPTION
The previous method of subtracting gravity when calibrating accelerometers required that the Z-axis is upward, but now a gravity vector is used.
Now, when I initialize the module with the Z-axis not facing up, the first few returns will be around 0 and then jump to the actual value, instead of the initialized position as ypr=0 (which is what I thought it would be before). And it doesn't have this problem: https://github.com/ElectronicCats/mpu6050/issues/77
It's worth to note that my tests show it's maybe better to keep the code unchanged and keep the z-axis calibrated upwards, just make sure the z-axis was calibrated upwards. Now all directions can be just as bad, and the calibration error is related to epsilon. 
(fix https://github.com/ElectronicCats/mpu6050/pull/78)