### PR TITLE
Fix bugs that prevent library compiling with the DEBUG macro set

### DIFF
--- a/src/MPU6050_6Axis_MotionApps20.cpp
+++ b/src/MPU6050_6Axis_MotionApps20.cpp
@@ -99,17 +99,32 @@ THE SOFTWARE.
 // compiler macro (Arduino IDE 1.0+ required).
 
 //#define DEBUG
+/* Control whether debugging macros are active at compile time */
+#undef DB_ACTIVE
 #ifdef DEBUG
-    #define DEBUG_PRINT(x) Serial.print(x)
-    #define DEBUG_PRINTF(x, y) Serial.print(x, y)
-    #define DEBUG_PRINTLN(x) Serial.println(x)
-    #define DEBUG_PRINTLNF(x, y) Serial.println(x, y)
+#define DB_ACTIVE 1
 #else
-    #define DEBUG_PRINT(x)
-    #define DEBUG_PRINTF(x, y)
-    #define DEBUG_PRINTLN(x)
-    #define DEBUG_PRINTLNF(x, y)
-#endif
+#define DB_ACTIVE 0
+#endif /* DEBUG */
+
+/*
+** Usage:  DB_PRINT((...));
+** Usage:  DB_PRINTLN((...));
+**
+** "..." is whatever extra arguments fmt requires (possibly nothing).
+**
+** The structure of the macros means that the code is always validated
+** but is not called when DEBUG is undefined.
+** -- See chapter 8 of 'The Practice of Programming', by Kernighan and Pike.
+*/
+#define DEBUG_PRINT(...)\
+            do { if (DB_ACTIVE) Serial.print(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTF(...)\
+            do { if (DB_ACTIVE) Serial.printf(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTLN(...)\
+            do { if (DB_ACTIVE) Serial.println(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTLNF(x, y)\
+            do { if (DB_ACTIVE) Serial.println(x, y); } while (0)
 
 #define MPU6050_DMP_CODE_SIZE       1929    // dmpMemory[]
 #define MPU6050_DMP_CONFIG_SIZE     192     // dmpConfig[]

--- a/src/MPU6050_6Axis_MotionApps612.cpp
+++ b/src/MPU6050_6Axis_MotionApps612.cpp
@@ -103,17 +103,32 @@ THE SOFTWARE.
 // compiler macro (Arduino IDE 1.0+ required).
 
 //#define DEBUG
+/* Control whether debugging macros are active at compile time */
+#undef DB_ACTIVE
 #ifdef DEBUG
-    #define DEBUG_PRINT(x) Serial.print(x)
-    #define DEBUG_PRINTF(x, y) Serial.print(x, y)
-    #define DEBUG_PRINTLN(x) Serial.println(x)
-    #define DEBUG_PRINTLNF(x, y) Serial.println(x, y)
+#define DB_ACTIVE 1
 #else
-    #define DEBUG_PRINT(x)
-    #define DEBUG_PRINTF(x, y)
-    #define DEBUG_PRINTLN(x)
-    #define DEBUG_PRINTLNF(x, y)
-#endif
+#define DB_ACTIVE 0
+#endif /* DEBUG */
+
+/*
+** Usage:  DB_PRINT((...));
+** Usage:  DB_PRINTLN((...));
+**
+** "..." is whatever extra arguments fmt requires (possibly nothing).
+**
+** The structure of the macros means that the code is always validated
+** but is not called when DEBUG is undefined.
+** -- See chapter 8 of 'The Practice of Programming', by Kernighan and Pike.
+*/
+#define DEBUG_PRINT(...)\
+            do { if (DB_ACTIVE) Serial.print(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTF(...)\
+            do { if (DB_ACTIVE) Serial.printf(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTLN(...)\
+            do { if (DB_ACTIVE) Serial.println(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTLNF(x, y)\
+            do { if (DB_ACTIVE) Serial.println(x, y); } while (0)
 
 #define MPU6050_DMP_CODE_SIZE       3062    // dmpMemory[]
 

--- a/src/MPU6050_9Axis_MotionApps41.cpp
+++ b/src/MPU6050_9Axis_MotionApps41.cpp
@@ -88,17 +88,32 @@ THE SOFTWARE.
 // compiler macro (Arduino IDE 1.0+ required).
 
 //#define DEBUG
+/* Control whether debugging macros are active at compile time */
+#undef DB_ACTIVE
 #ifdef DEBUG
-    #define DEBUG_PRINT(x) Serial.print(x)
-    #define DEBUG_PRINTF(x, y) Serial.print(x, y)
-    #define DEBUG_PRINTLN(x) Serial.println(x)
-    #define DEBUG_PRINTLNF(x, y) Serial.println(x, y)
+#define DB_ACTIVE 1
 #else
-    #define DEBUG_PRINT(x)
-    #define DEBUG_PRINTF(x, y)
-    #define DEBUG_PRINTLN(x)
-    #define DEBUG_PRINTLNF(x, y)
-#endif
+#define DB_ACTIVE 0
+#endif /* DEBUG */
+
+/*
+** Usage:  DB_PRINT((...));
+** Usage:  DB_PRINTLN((...));
+**
+** "..." is whatever extra arguments fmt requires (possibly nothing).
+**
+** The structure of the macros means that the code is always validated
+** but is not called when DEBUG is undefined.
+** -- See chapter 8 of 'The Practice of Programming', by Kernighan and Pike.
+*/
+#define DEBUG_PRINT(...)\
+            do { if (DB_ACTIVE) Serial.print(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTF(...)\
+            do { if (DB_ACTIVE) Serial.printf(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTLN(...)\
+            do { if (DB_ACTIVE) Serial.println(__VA_ARGS__); } while (0)
+#define DEBUG_PRINTLNF(x, y)\
+            do { if (DB_ACTIVE) Serial.println(x, y); } while (0)
 
 #define MPU6050_DMP_CODE_SIZE       1962    // dmpMemory[]
 #define MPU6050_DMP_CONFIG_SIZE     232     // dmpConfig[]
@@ -345,10 +360,10 @@ uint8_t MPU6050_9Axis_MotionApps41::dmpInitialize() {
     setSleepEnabled(false);
 
     // get MPU product ID
-    DEBUG_PRINTLN(F("Getting product ID..."));
+    //DEBUG_PRINTLN(F("Getting product ID..."));
     //uint8_t productID = 0; //getProductID();
-    DEBUG_PRINT(F("Product ID = "));
-    DEBUG_PRINT(productID);
+    //DEBUG_PRINT(F("Product ID = "));
+    //DEBUG_PRINT(productID);
 
     // get MPU hardware revision
     DEBUG_PRINTLN(F("Selecting user bank 16..."));


### PR DESCRIPTION
Remove stale debug code that attempts to output the ProductID that is no longer being retrieved.

Update DEBUG_PRINT macros so that the code is always validated at compile time but is not called when DEBUG is undefined. This helps prevent stale debug code from accumulating when the debug version is not regularly compiled.

Fixes issue #80 
