### PR TITLE
Update MPUTeapot.pde (doesn't run without correction)

### DIFF
--- a/examples/MPU6050_DMP6/Processing/MPUTeapot/MPUTeapot.pde
+++ b/examples/MPU6050_DMP6/Processing/MPUTeapot/MPUTeapot.pde
@@ -42,7 +42,7 @@ void setup() {
     smooth();
   
     println(Serial.list()); //Display serial port list for debugging/clarity
-    tring portName = "COMXX"; //Define the port, port format may be different on Linux/Mac
+    String portName = "COMXX"; //Define the port, port format may be different on Linux/Mac
     port = new Serial(this, portName, 115200); // Open the serial port
     port.write('r'); // Send a single character to trigger DMP init/start
 }


### PR DESCRIPTION
typo line 45 ("tring" in place of "String")

Thanks,

Sam