### PR TITLE
MPU 92.65 can now be detected by mpu.testConnection()

### DIFF
--- a/src/MPU6050.cpp
+++ b/src/MPU6050.cpp
@@ -163,7 +163,7 @@ float MPU6050_Base::get_gyro_resolution() {
  */
 bool MPU6050_Base::testConnection() {
   uint8_t deviceId = getDeviceID();
-  return (deviceId == 0x34) || (deviceId == 0xC);
+  return (deviceId == 0x34) || (deviceId == 0xC) || (deviceId == 0x3A);
 }
 
 // AUX_VDDIO register (InvenSense demo code calls this RA_*G_OFFS_TC)


### PR DESCRIPTION
MPU 92.65 was not detected by mpu.testConnection(); thus, its address (0x3A) is added to the testConnection() return logic.